### PR TITLE
NOJIRA: Run image as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:1.23 as builder
 
+RUN useradd -u 150 apprunner
 FROM scratch
 
 COPY opencost-cacher /app/opencost-cacher
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+USER apprunner
 ENTRYPOINT ["/app/opencost-cacher"]


### PR DESCRIPTION
Trivy reports a high security issue causing pipelines to fail: https://github.com/kartverket/opencost-cacher/security/code-scanning/2

By adding a USER command we can resolve the issue.
